### PR TITLE
Use environment-configurable server port, log public URL, and add React video challenge frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Video Challenge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/AdminApp.jsx
+++ b/frontend/src/AdminApp.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function AdminApp({ videos, onApprove, onReject }) {
+  if (videos.length === 0) {
+    return <p>No videos in queue.</p>
+  }
+
+  return (
+    <div>
+      {videos.map(v => (
+        <div key={v.id} style={{ marginBottom: '1rem' }}>
+          <video src={v.url} controls width="250" />
+          <p>Status: {v.status}</p>
+          {v.status === 'pending' && (
+            <>
+              <button onClick={() => onApprove(v.id)}>Mark Completed</button>
+              <button onClick={() => onReject(v.id)}>Reject</button>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react'
+import UserApp from './UserApp.jsx'
+import AdminApp from './AdminApp.jsx'
+
+export default function App() {
+  const [videos, setVideos] = useState([])
+  const [view, setView] = useState('user')
+
+  const handleUpload = async file => {
+    // Placeholder for YouTube API integration
+    const id = Date.now()
+    const url = URL.createObjectURL(file)
+    setVideos(v => [...v, { id, url, status: 'pending', file }])
+    alert('Video uploaded (simulated) to YouTube')
+  }
+
+  const markCompleted = id => {
+    setVideos(v => v.map(video => video.id === id ? { ...video, status: 'completed' } : video))
+  }
+
+  const reject = id => {
+    setVideos(v => v.map(video => video.id === id ? { ...video, status: 'rejected' } : video))
+  }
+
+  return (
+    <div>
+      <nav>
+        <button onClick={() => setView('user')}>User</button>
+        <button onClick={() => setView('admin')}>Admin</button>
+      </nav>
+      {view === 'user'
+        ? <UserApp onUpload={handleUpload} />
+        : <AdminApp videos={videos} onApprove={markCompleted} onReject={reject} />}
+    </div>
+  )
+}

--- a/frontend/src/UserApp.jsx
+++ b/frontend/src/UserApp.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+
+export default function UserApp({ onUpload }) {
+  const [file, setFile] = useState(null)
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    if (file) {
+      onUpload(file)
+      setFile(null)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="file"
+        accept="video/*"
+        capture="user"
+        onChange={e => setFile(e.target.files[0])}
+      />
+      <button type="submit" disabled={!file}>Upload to YouTube</button>
+    </form>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var os = require('os');
 var app = express();
 
 app.get('/', function(req, res){
@@ -6,4 +7,22 @@ app.get('/', function(req, res){
     console.log("Requested route: /");
 });
 
-app.listen(80);
+var port = process.env.PORT || 3000;
+app.listen(port, function() {
+    var host = 'localhost';
+    var interfaces = os.networkInterfaces();
+    for (var name in interfaces) {
+        var ifaceList = interfaces[name];
+        for (var i = 0; i < ifaceList.length; i++) {
+            var iface = ifaceList[i];
+            if (iface.family === 'IPv4' && !iface.internal) {
+                host = iface.address;
+                break;
+            }
+        }
+        if (host !== 'localhost') {
+            break;
+        }
+    }
+    console.log('Server is listening at http://' + host + ':' + port);
+});


### PR DESCRIPTION
## Summary
- allow server to listen on a configurable port instead of hardcoded 80
- log the chosen port and publicly accessible URL when server starts
- add a minimal React frontend so users can record videos and admins can review and mark challenges complete

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891ecb4ed10832b9cb572be53c7a078